### PR TITLE
Removing support for p12 key loading due to issue with OpenSSL 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [References](#references)
 - [Usage](#usage)
   - [Prerequisites](#prerequisites)
+    - [Loading the Decryption Key](#loading-the-decryption-key)
   - [Adding the Library to Your Project](#adding-the-libraries-to-your-project)
   - [Performing Field Level Encryption and Decryption](#performing-payload-encryption-and-decryption)
   - [Integrating with OpenAPI Generator API Client Libraries](#integrating-with-openapi-generator-api-client-libraries)
@@ -43,6 +44,21 @@ As part of this set up, you'll receive:
 
 - A public request encryption certificate (aka _Client Encryption Keys_)
 - A private response decryption key (aka _Mastercard Encryption Keys_)
+
+#### Loading the Decryption Key <a name="loading-the-decryption-key"></a>
+
+By default, the decryption key will be given in as a PKCS#12 password-protected file.
+The key can be loaded using either of the 2 methods below.
+
+1. The following code shows how to load the decryption key using `OpenSSL`:
+```ruby
+require 'openssl'
+
+is = File.binread("<insert PKCS#12 key file path>");
+signing_key = OpenSSL::PKCS12.new(is, "<insert key password>").key;
+```
+
+2. Follow our guide on [Exporting Your Signing Key](https://developer.mastercard.com/platform/documentation/security-and-authentication/using-oauth-1a-to-access-mastercard-apis/#exporting-your-signing-key)
 
 ### Installation <a name="adding-the-libraries-to-your-project"></a>
 

--- a/lib/mcapi/encryption/crypto/crypto.rb
+++ b/lib/mcapi/encryption/crypto/crypto.rb
@@ -23,8 +23,6 @@ module McAPI
         @cert = OpenSSL::X509::Certificate.new(IO.binread(config['encryptionCertificate']))
         if config['privateKey']
           @private_key = OpenSSL::PKey.read(IO.binread(config['privateKey']))
-        elsif config['keyStore']
-          @private_key = OpenSSL::PKCS12.new(IO.binread(config['keyStore']), config['keyStorePassword']).key
         end
         @oaep_hashing_alg = config['oaepPaddingDigestAlgorithm']
         @encrypted_value_field_name = config['encryptedValueFieldName']

--- a/lib/mcapi/encryption/crypto/jwe-crypto.rb
+++ b/lib/mcapi/encryption/crypto/jwe-crypto.rb
@@ -23,8 +23,6 @@ module McAPI
         @cert = OpenSSL::X509::Certificate.new(IO.binread(config['encryptionCertificate']))
         if config['privateKey']
           @private_key = OpenSSL::PKey.read(IO.binread(config['privateKey']))
-        elsif config['keyStore']
-          @private_key = OpenSSL::PKCS12.new(IO.binread(config['keyStore']), config['keyStorePassword']).key
         end
         @encrypted_value_field_name = config['encryptedValueFieldName'] || 'encryptedData'
         @public_key_fingerprint = compute_public_fingerprint

--- a/mastercard-client-encryption.gemspec
+++ b/mastercard-client-encryption.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'mastercard-client-encryption'
-  spec.version = '1.3.1'
+  spec.version = '1.3.2'
   spec.authors = ['Mastercard']
   spec.required_ruby_version = '>= 2.4.4'
 

--- a/test/test_crypto_config.rb
+++ b/test/test_crypto_config.rb
@@ -63,16 +63,6 @@ class TestCryptoConfig < Minitest::Test
     assert_equal 'Z+gOGbilDalFcm4yZyYj1pr/N1qdg8QYECbsTvu3yAA=', fingerprint
   end
 
-  def test_config_with_private_keystore
-    config = @test_config.dup
-    config.delete('privateKey')
-    config['keyStore'] = './test/res/test_key.p12'
-    config['keyStoreAlias'] = 'mykeyalias'
-    config['keyStorePassword'] = 'Password1'
-    crypto = McAPI::Encryption::Crypto.new(config)
-    assert(crypto)
-  end
-
   def test_fingerprint_wrong_type
     crypto = McAPI::Encryption::Crypto.new(@test_config)
     assert_exp_equals(RuntimeError, 'Selected public fingerprint not supported') do


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Description
Removing support for p12 key loading due to issue with OpenSSL 3+.
See failing github action for more information: https://github.com/Mastercard/client-encryption-ruby/actions/runs/4115988705/jobs/7105442550
